### PR TITLE
T020: Handle events API 404 gracefully

### DIFF
--- a/github/poller.py
+++ b/github/poller.py
@@ -101,7 +101,11 @@ def get_repo_events(owner: str, repo: str,
         '--field', f'per_page={per_page}',
     ])
     if code != 0:
-        logger.error(f'Failed to get events for {owner}/{repo}: {err}')
+        # Events API returns 404 for some repos (permissions, new repos, etc.)
+        if '404' in err or 'Not Found' in err:
+            logger.debug(f'Events API not available for {owner}/{repo} (404)')
+        else:
+            logger.error(f'Failed to get events for {owner}/{repo}: {err}')
         return []
     return _parse_json(out)
 

--- a/specs/002-refactor-harden/tasks.md
+++ b/specs/002-refactor-harden/tasks.md
@@ -2,3 +2,4 @@
 
 ## DRY
 - [x] T019: Extract github/gh_cli.py — shared gh_command + parse_json, update poller, dispatcher, settings to import from it
+- [x] T020: Handle events API 404 gracefully — downgrade to debug log, skip silently for repos without events endpoint


### PR DESCRIPTION
## Summary
- Events API returns 404 for some repos (new, permissions). Downgrade from error to debug log.

## Test plan
- [x] 39 tests pass
- [x] Verified with live smoke test against grobomo/github-agent