### PR TITLE
T069: Remove redundant datetime import

### DIFF
--- a/main.py
+++ b/main.py
@@ -296,7 +296,6 @@ def run_agent(account: str, repos: list[str] = None,
                 # Account summary: daily
                 acct = memory_store.load_account_memory(account)
                 last_acct = acct.get('last_compacted_at', '')
-                from datetime import datetime, timezone
                 now = datetime.now(timezone.utc).isoformat()
                 if not last_acct or last_acct[:10] != now[:10]:
                     if compactor.compact_account():

--- a/specs/011-cleanup/spec.md
+++ b/specs/011-cleanup/spec.md
@@ -1,0 +1,7 @@
+# Spec 011: Code Cleanup
+
+## Problem
+Redundant inline import of `datetime` in main.py after top-level import was added in Spec 010.
+
+## Solution
+Remove the redundant `from datetime import datetime, timezone` inside the poll loop (line 299) since it's now imported at the top of the file.

--- a/specs/011-cleanup/tasks.md
+++ b/specs/011-cleanup/tasks.md
@@ -1,0 +1,3 @@
+# Spec 011: Code Cleanup — Tasks
+
+- [x] T069: Remove redundant datetime import in main.py


### PR DESCRIPTION
## Summary
- Remove inline `from datetime import datetime, timezone` that became redundant after Spec 010 added it to top-level imports

## Test plan
- [x] 90 tests passing